### PR TITLE
Allows the user to add basic fields

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,0 +1,3 @@
+import DS from 'ember-data';
+
+export default DS.FixtureAdapter.extend();

--- a/app/components/element-drawer.js
+++ b/app/components/element-drawer.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+    fields: [
+        'Fieldset',
+        'Charfield',
+        'Textfield',
+        'Select',
+        'Multiselect',
+        'Datefield',
+        'Datetimefield',
+        'Filefieled',
+        'Imagefield',
+        'Integerfield',
+        'Mailfield',
+        'Urlfield',
+        'Passwordfield',
+        'Hiddenfield',
+    ]
+});

--- a/app/components/element-drawer.js
+++ b/app/components/element-drawer.js
@@ -16,5 +16,12 @@ export default Ember.Component.extend({
         'Urlfield',
         'Passwordfield',
         'Hiddenfield',
-    ]
+    ],
+
+    actions: {
+        addField: function(field) {
+            this.sendAction('addField', field);
+        }
+    }
+
 });

--- a/app/components/element-drawer.js
+++ b/app/components/element-drawer.js
@@ -19,8 +19,8 @@ export default Ember.Component.extend({
     ],
 
     actions: {
-        addField: function(field) {
-            this.sendAction('addField', field);
+        addFormElement: function(field) {
+            this.sendAction('addFormElement', field);
         }
     }
 

--- a/app/components/form-element.js
+++ b/app/components/form-element.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({});

--- a/app/components/form-element.js
+++ b/app/components/form-element.js
@@ -7,6 +7,17 @@ export default Ember.Component.extend({
       return this.get('_isEditing');
   }.property('_isEditing'),
 
+  formElementTemplate: function() {
+    // Set the default templateName to 'charfield', bacause during loading
+    // time, the formElement is not accessible and all of its attributes
+    // are 'undefined'.
+    var templateName = 'charfield';
+    if (typeof(this.get('formElement.elementType')) !== 'undefined') {
+      templateName = this.get('formElement.elementType').toLowerCase();
+    }
+    return 'components/-form-element-' + templateName;
+  }.property('formElement.elementType'),
+
   didInsertElement: function() {
     // While inserting a new formElement, it's label will be "" and
     // we want to edit it. A computet property, looking for _isEditing

--- a/app/components/form-element.js
+++ b/app/components/form-element.js
@@ -1,3 +1,26 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({});
+export default Ember.Component.extend({
+  _isEditing: false,
+
+  isEditing: function() {
+      return this.get('_isEditing');
+  }.property('_isEditing'),
+
+  didInsertElement: function() {
+    // While inserting a new formElement, it's label will be "" and
+    // we want to edit it. A computet property, looking for _isEditing
+    // and formElement.label would not work, because during render
+    // time of the page the formElement.label would be undefined.
+    if (this.get('formElement.label') === "") {
+      this.set('_isEditing', true);
+    }
+  },
+
+  actions: {
+    togglIsEditing: function() {
+        this.toggleProperty('_isEditing');
+    },
+  }
+
+});

--- a/app/components/form-element.js
+++ b/app/components/form-element.js
@@ -8,7 +8,7 @@ export default Ember.Component.extend({
   }.property('_isEditing'),
 
   formElementTemplate: function() {
-    // Set the default templateName to 'charfield', bacause during loading
+    // Set the default templateName to 'charfield', because during loading
     // time, the formElement is not accessible and all of its attributes
     // are 'undefined'.
     var templateName = 'charfield';
@@ -20,7 +20,7 @@ export default Ember.Component.extend({
 
   didInsertElement: function() {
     // While inserting a new formElement, it's label will be "" and
-    // we want to edit it. A computet property, looking for _isEditing
+    // we want to edit it. A computed property, looking for _isEditing
     // and formElement.label would not work, because during render
     // time of the page the formElement.label would be undefined.
     if (this.get('formElement.label') === "") {

--- a/app/components/form-element.js
+++ b/app/components/form-element.js
@@ -1,11 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  _isEditing: false,
-
-  isEditing: function() {
-      return this.get('_isEditing');
-  }.property('_isEditing'),
+  isEditing: false,
 
   formElementTemplate: function() {
     // Set the default templateName to 'charfield', because during loading
@@ -20,17 +16,17 @@ export default Ember.Component.extend({
 
   didInsertElement: function() {
     // While inserting a new formElement, it's label will be "" and
-    // we want to edit it. A computed property, looking for _isEditing
+    // we want to edit it. A computed property, looking for isEditing
     // and formElement.label would not work, because during render
     // time of the page the formElement.label would be undefined.
     if (this.get('formElement.label') === "") {
-      this.set('_isEditing', true);
+      this.set('isEditing', true);
     }
   },
 
   actions: {
     togglIsEditing: function() {
-        this.toggleProperty('_isEditing');
+        this.toggleProperty('isEditing');
     },
   }
 

--- a/app/components/hopper-frontend.js
+++ b/app/components/hopper-frontend.js
@@ -6,6 +6,8 @@ export default Ember.Component.extend({
 
     didInsertElement: function() {
         this.set('store', this.get('targetObject.store'));
+        // set this static for now
+        // will be replaced with our API call later
         this.set('form', this.store.find('form', 1 ));
     },
 

--- a/app/components/hopper-frontend.js
+++ b/app/components/hopper-frontend.js
@@ -5,8 +5,8 @@ export default Ember.Component.extend({
     isTitleBeingEdited: false,
 
     didInsertElement: function() {
-        var store = this.get('targetObject.store');
-        this.set('form', store.find('form', 1 ));
+        this.set('store', this.get('targetObject.store'));
+        this.set('form', this.store.find('form', 1 ));
     },
 
     actions: {
@@ -18,6 +18,10 @@ export default Ember.Component.extend({
         },
         acceptTitleChange: function () {
             this.set('isTitleBeingEdited', false);
+        },
+        addField: function(field) {
+            var newElement = this.store.createRecord('formElement', {fieldType: field});
+            this.get('form').get('formElements').addObject(newElement);
         }
     }
 });

--- a/app/components/hopper-frontend.js
+++ b/app/components/hopper-frontend.js
@@ -20,7 +20,7 @@ export default Ember.Component.extend({
             this.set('isTitleBeingEdited', false);
         },
         addField: function(field) {
-            var newElement = this.store.createRecord('formElement', {label: '', fieldType: field});
+            var newElement = this.store.createRecord('formElement', {label: '', elementType: field});
             this.get('form').get('formElements').addObject(newElement);
         }
     }

--- a/app/components/hopper-frontend.js
+++ b/app/components/hopper-frontend.js
@@ -11,7 +11,7 @@ export default Ember.Component.extend({
 
     actions: {
         toggleIsElementDrawerOpen: function () {
-            this.set('isElementDrawerOpen', !this.get('isElementDrawerOpen'));
+            this.toggleProperty('isElementDrawerOpen');
         },
         editTitle: function () {
             this.set('isTitleBeingEdited', true);

--- a/app/components/hopper-frontend.js
+++ b/app/components/hopper-frontend.js
@@ -19,7 +19,7 @@ export default Ember.Component.extend({
         acceptTitleChange: function () {
             this.set('isTitleBeingEdited', false);
         },
-        addField: function(field) {
+        addFormElement: function(field) {
             var newElement = this.store.createRecord('formElement', {label: '', elementType: field});
             this.get('form').get('formElements').addObject(newElement);
         }

--- a/app/components/hopper-frontend.js
+++ b/app/components/hopper-frontend.js
@@ -20,7 +20,7 @@ export default Ember.Component.extend({
             this.set('isTitleBeingEdited', false);
         },
         addField: function(field) {
-            var newElement = this.store.createRecord('formElement', {fieldType: field});
+            var newElement = this.store.createRecord('formElement', {label: '', fieldType: field});
             this.get('form').get('formElements').addObject(newElement);
         }
     }

--- a/app/components/hopper-frontend.js
+++ b/app/components/hopper-frontend.js
@@ -3,7 +3,11 @@ import Ember from 'ember';
 export default Ember.Component.extend({
     isElementDrawerOpen: false,
     isTitleBeingEdited: false,
-    formTitle: 'My awesome Festival',
+
+    didInsertElement: function() {
+        var store = this.get('targetObject.store');
+        this.set('form', store.find('form', 1 ));
+    },
 
     actions: {
         toggleIsElementDrawerOpen: function () {

--- a/app/models/form-element.js
+++ b/app/models/form-element.js
@@ -1,0 +1,16 @@
+import DS from 'ember-data';
+
+var FormElement = DS.Model.extend({
+    label: DS.attr('string'),
+    immutable: DS.attr('bool'),
+    required: DS.attr('required'),
+});
+
+FormElement.reopenClass({
+    FIXTURES: [
+        { id: "1", label: 'First Name', required: false, immutable: true},
+        { id: "2", label: 'Last Name', required: true, immutable: false},
+    ]
+});
+
+export default FormElement;

--- a/app/models/form-element.js
+++ b/app/models/form-element.js
@@ -4,13 +4,13 @@ var FormElement = DS.Model.extend({
     label: DS.attr('string'),
     immutable: DS.attr('bool'),
     required: DS.attr('required'),
-    fieldType: DS.attr('string'),
+    elementType: DS.attr('string'),
 });
 
 FormElement.reopenClass({
     FIXTURES: [
-        { id: "1", label: 'First Name', required: false, immutable: true, fieldType: 'Charfield'},
-        { id: "2", label: 'Last Name', required: true, immutable: false, fieldType: 'Charfield'},
+        { id: "1", label: 'First Name', required: false, immutable: true, elementType: 'Charfield'},
+        { id: "2", label: 'Last Name', required: true, immutable: false, elementType: 'Charfield'},
     ]
 });
 

--- a/app/models/form-element.js
+++ b/app/models/form-element.js
@@ -4,12 +4,13 @@ var FormElement = DS.Model.extend({
     label: DS.attr('string'),
     immutable: DS.attr('bool'),
     required: DS.attr('required'),
+    fieldType: DS.attr('string'),
 });
 
 FormElement.reopenClass({
     FIXTURES: [
-        { id: "1", label: 'First Name', required: false, immutable: true},
-        { id: "2", label: 'Last Name', required: true, immutable: false},
+        { id: "1", label: 'First Name', required: false, immutable: true, fieldType: 'Charfield'},
+        { id: "2", label: 'Last Name', required: true, immutable: false, fieldType: 'Charfield'},
     ]
 });
 

--- a/app/models/form.js
+++ b/app/models/form.js
@@ -2,11 +2,12 @@ import DS from 'ember-data';
 
 var Form = DS.Model.extend({
     title: DS.attr('string'),
+    formElements: DS.hasMany('formElements', { async: true })
 });
 
 Form.reopenClass({
     FIXTURES: [
-        { id: "1", title: 'My awesome Movie', }
+        { id: "1", title: 'My awesome Movie', formElements: [1, 2]}
     ]
 });
 

--- a/app/models/form.js
+++ b/app/models/form.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+
+var Form = DS.Model.extend({
+    title: DS.attr('string'),
+});
+
+Form.reopenClass({
+    FIXTURES: [
+        { id: "1", title: 'My awesome Movie', }
+    ]
+});
+
+export default Form;

--- a/app/routes/fields.js
+++ b/app/routes/fields.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
     model: function() {
+        // set this static for now
+        // will be replaced with our API call later
         return this.store.find('form', 1);
     }
 });

--- a/app/routes/fields.js
+++ b/app/routes/fields.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+    model: function() {
+        return this.store.find('form', 1);
+    }
 });

--- a/app/routes/form.js
+++ b/app/routes/form.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
     model: function() {
+        // set this static for now
+        // will be replaced with our API call later
         return this.store.find('form', 1);
     }
 });

--- a/app/routes/form.js
+++ b/app/routes/form.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+    model: function() {
+        return this.store.find('form', 1);
+    }
 });

--- a/app/templates/components/-form-element-charfield.hbs
+++ b/app/templates/components/-form-element-charfield.hbs
@@ -1,0 +1,12 @@
+{{#if isEditing}}
+<div class="field">
+    {{input value=formElement.label}}
+    <a {{ action "togglIsEditing" on="click"}}>Save</a>
+</div>
+{{else}}
+<div {{bind-attr class=":field formElement.immutable:immutable" }}
+        {{action "togglIsEditing" on="doubleClick"}}>
+    <label>{{ formElement.label }}{{#if formElement.required}}*{{/if}}:</label>
+    <span><input type="text" name="first_name" disabled></span>
+</div>
+{{/if}}

--- a/app/templates/components/element-drawer.hbs
+++ b/app/templates/components/element-drawer.hbs
@@ -1,6 +1,6 @@
 <ul>
     {{#each field in fields}}
-    <li {{action "addField" field on="click"}}>
+    <li {{action "addFormElement" field on="click"}}>
         <i class="fa fa-angle-double-left"></i> {{ field }}
     </li>
     {{/each}}

--- a/app/templates/components/element-drawer.hbs
+++ b/app/templates/components/element-drawer.hbs
@@ -1,0 +1,5 @@
+<ul>
+    {{#each field in fields}}
+    <li><i class="fa fa-angle-double-left"></i> {{ field }}</li>
+    {{/each}}
+</ul>

--- a/app/templates/components/element-drawer.hbs
+++ b/app/templates/components/element-drawer.hbs
@@ -1,5 +1,7 @@
 <ul>
     {{#each field in fields}}
-    <li><i class="fa fa-angle-double-left"></i> {{ field }}</li>
+    <li {{action "addField" field on="click"}}>
+        <i class="fa fa-angle-double-left"></i> {{ field }}
+    </li>
     {{/each}}
 </ul>

--- a/app/templates/components/form-element.hbs
+++ b/app/templates/components/form-element.hbs
@@ -1,12 +1,1 @@
-{{#if isEditing}}
-<div class="field">
-    {{input value=formElement.label}}
-    <a {{ action "togglIsEditing" on="click"}}>Save</a>
-</div>
-{{else}}
-<div {{bind-attr class=":field formElement.immutable:immutable" }}
-        {{action "togglIsEditing" on="doubleClick"}}>
-    <label>{{ formElement.label }}{{#if formElement.required}}*{{/if}}:</label>
-    <span><input type="text" name="first_name" disabled></span>
-</div>
-{{/if}}
+{{ partial formElementTemplate }}

--- a/app/templates/components/form-element.hbs
+++ b/app/templates/components/form-element.hbs
@@ -1,0 +1,4 @@
+<div {{bind-attr class=":field formElement.immutable:immutable" }}>
+    <label>{{ formElement.label }}{{#if formElement.required}}*{{/if}}:</label>
+    <span><input type="text" name="first_name" disabled></span>
+</div>

--- a/app/templates/components/form-element.hbs
+++ b/app/templates/components/form-element.hbs
@@ -1,4 +1,12 @@
-<div {{bind-attr class=":field formElement.immutable:immutable" }}>
+{{#if isEditing}}
+<div class="field">
+    {{input value=formElement.label}}
+    <a {{ action "togglIsEditing" on="click"}}>Save</a>
+</div>
+{{else}}
+<div {{bind-attr class=":field formElement.immutable:immutable" }}
+        {{action "togglIsEditing" on="doubleClick"}}>
     <label>{{ formElement.label }}{{#if formElement.required}}*{{/if}}:</label>
     <span><input type="text" name="first_name" disabled></span>
 </div>
+{{/if}}

--- a/app/templates/components/hopper-frontend.hbs
+++ b/app/templates/components/hopper-frontend.hbs
@@ -48,7 +48,7 @@
     <div id="hopper-element-drawer" {{bind-attr class=":hopper-col :columns :hopper-col-last isElementDrawerOpen:medium-3:medium-1"}}>
         <div class="hopper-element-drawer">
             <div {{bind-attr class=':available-fields isElementDrawerOpen:open'}}>
-                {{ element-drawer addField='addField'}}
+                {{ element-drawer addFormElement='addFormElement'}}
             </div>
             <div class="element-drawer-control" {{action "toggleIsElementDrawerOpen" on="click"}}>
                 <i id="toggl-element-drawer-icon" {{bind-attr class=":fa :hopper-col-last isElementDrawerOpen:fa-caret-right:fa-caret-left"}}>

--- a/app/templates/components/hopper-frontend.hbs
+++ b/app/templates/components/hopper-frontend.hbs
@@ -8,9 +8,9 @@
                         {{edit-title-input
                             focus-out="acceptTitleChange"
                             insert-newline="acceptTitleChange"
-                            value=formTitle}}
+                            value=form.title}}
                     {{else}}
-                        <h1 {{action "editTitle" on="doubleClick"}}>{{ formTitle }}</h1>
+                        <h1 {{action "editTitle" on="doubleClick"}}>{{ form.title }}</h1>
                     {{/if}}
                 </div>
                 <div class="form-meta-toggl">

--- a/app/templates/components/hopper-frontend.hbs
+++ b/app/templates/components/hopper-frontend.hbs
@@ -48,24 +48,7 @@
     <div id="hopper-element-drawer" {{bind-attr class=":hopper-col :columns :hopper-col-last isElementDrawerOpen:medium-3:medium-1"}}>
         <div class="hopper-element-drawer">
             <div {{bind-attr class=':available-fields isElementDrawerOpen:open'}}>
-                <div> <!-- this will be replaced with a component for the available fields -->
-                    <ul>
-                        <li><i class="fa fa-angle-double-left"></i> Fieldset</li>
-                        <li><i class="fa fa-angle-double-left"></i> Charfield</li>
-                        <li><i class="fa fa-angle-double-left"></i> Textfield</li>
-                        <li><i class="fa fa-angle-double-left"></i> Select</li>
-                        <li><i class="fa fa-angle-double-left"></i> Multiselect</li>
-                        <li><i class="fa fa-angle-double-left"></i> Datefield</li>
-                        <li><i class="fa fa-angle-double-left"></i> Datetimefield</li>
-                        <li><i class="fa fa-angle-double-left"></i> Filefieled</li>
-                        <li><i class="fa fa-angle-double-left"></i> Imagefield</li>
-                        <li><i class="fa fa-angle-double-left"></i> Integerfield</li>
-                        <li><i class="fa fa-angle-double-left"></i> Mailfield</li>
-                        <li><i class="fa fa-angle-double-left"></i> Urlfield</li>
-                        <li><i class="fa fa-angle-double-left"></i> Passwordfield</li>
-                        <li><i class="fa fa-angle-double-left"></i> Hiddenfield</li>
-                    </ul>
-                </div>
+                {{ element-drawer }}
             </div>
             <div class="element-drawer-control" {{action "toggleIsElementDrawerOpen" on="click"}}>
                 <i id="toggl-element-drawer-icon" {{bind-attr class=":fa :hopper-col-last isElementDrawerOpen:fa-caret-right:fa-caret-left"}}>

--- a/app/templates/components/hopper-frontend.hbs
+++ b/app/templates/components/hopper-frontend.hbs
@@ -48,7 +48,7 @@
     <div id="hopper-element-drawer" {{bind-attr class=":hopper-col :columns :hopper-col-last isElementDrawerOpen:medium-3:medium-1"}}>
         <div class="hopper-element-drawer">
             <div {{bind-attr class=':available-fields isElementDrawerOpen:open'}}>
-                {{ element-drawer }}
+                {{ element-drawer addField='addField'}}
             </div>
             <div class="element-drawer-control" {{action "toggleIsElementDrawerOpen" on="click"}}>
                 <i id="toggl-element-drawer-icon" {{bind-attr class=":fa :hopper-col-last isElementDrawerOpen:fa-caret-right:fa-caret-left"}}>

--- a/app/templates/fields.hbs
+++ b/app/templates/fields.hbs
@@ -1,8 +1,5 @@
 <div> <!-- this will be replaced with a component for choosen fields -->
     {{#each element in model.formElements}}
-        <div {{bind-attr class=":field element.immutable:immutable" }}>
-            <label>{{ element.label }}{{#if element.required}}*{{/if}}:</label>
-            <span><input type="text" name="first_name" disabled></span>
-        </div>
+        {{ form-element formElement=element }}
     {{/each}}
 </div>

--- a/app/templates/fields.hbs
+++ b/app/templates/fields.hbs
@@ -1,22 +1,8 @@
 <div> <!-- this will be replaced with a component for choosen fields -->
-    <div class="fieldset">
-        <h2>Director</h2>
-        <div class="field immutable">
-            <label>A kindof long First Name*:</label>
+    {{#each element in model.formElements}}
+        <div {{bind-attr class=":field element.immutable:immutable" }}>
+            <label>{{ element.label }}{{#if element.required}}*{{/if}}:</label>
             <span><input type="text" name="first_name" disabled></span>
         </div>
-        <div class="field immutable">
-        <label>Last Name*:</label>
-            <span><input type="text" name="first_name" disabled></span>
-        </div>
-    </div>
-    <div class="field">
-        <label>Genres*:</label>
-        <span>
-            <input type="checkbox" name="genres" value="action" disabled> Action <br/>
-            <input type="checkbox" name="genres" value="documentatry" disabled> Documentary <br/>
-            <input type="checkbox" name="genres" value="drama" disabled> Drama <br/>
-            <input type="checkbox" name="genres" value="sci-fi" disabled> Sci-Fi <br/>
-        </span>
-    </div>
+    {{/each}}
 </div>

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('adapter:application', 'ApplicationAdapter', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/components/element-drawer-test.js
+++ b/tests/unit/components/element-drawer-test.js
@@ -20,17 +20,17 @@ test('it renders', function(assert) {
   assert.equal(component._state, 'inDOM');
 });
 
-test('addField action', function(assert) {
-  // make sure, the component bubbles up the addField action to the next
+test('addFormElement action', function(assert) {
+  // make sure, the component bubbles up the addFormElement action to the next
   // component
   assert.expect(2);
   var fieldname = 'Fieldname';
   var sendActionStub = function(actionName, args) {
-    assert.equal(actionName, 'addField');
+    assert.equal(actionName, 'addFormElement');
     assert.equal(args, fieldname);
   };
 
   var component = this.subject();
   component.sendAction = sendActionStub;
-  component.send('addField', fieldname);
+  component.send('addFormElement', fieldname);
 });

--- a/tests/unit/components/element-drawer-test.js
+++ b/tests/unit/components/element-drawer-test.js
@@ -19,3 +19,18 @@ test('it renders', function(assert) {
   this.render();
   assert.equal(component._state, 'inDOM');
 });
+
+test('addField action', function(assert) {
+  // make sure, the component bubbles up the addField action to the next
+  // component
+  assert.expect(2);
+  var fieldname = 'Fieldname';
+  var sendActionStub = function(actionName, args) {
+    assert.equal(actionName, 'addField');
+    assert.equal(args, fieldname);
+  };
+
+  var component = this.subject();
+  component.sendAction = sendActionStub;
+  component.send('addField', fieldname);
+});

--- a/tests/unit/components/element-drawer-test.js
+++ b/tests/unit/components/element-drawer-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('element-drawer', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});

--- a/tests/unit/components/form-element-test.js
+++ b/tests/unit/components/form-element-test.js
@@ -1,3 +1,4 @@
+import resolver from '../../helpers/resolver';
 import {
   moduleForComponent,
   test
@@ -6,6 +7,10 @@ import {
 moduleForComponent('form-element', {
   // specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar']
+  setup: function() {
+    this.container.register('template:components/-form-element-charfield',
+    resolver.resolve('template:components/-form-element-charfield'));
+  }
 });
 
 test('it renders', function(assert) {

--- a/tests/unit/components/form-element-test.js
+++ b/tests/unit/components/form-element-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('form-element', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});

--- a/tests/unit/components/form-element-test.js
+++ b/tests/unit/components/form-element-test.js
@@ -29,11 +29,11 @@ test('togglIsEditing action', function(assert) {
   assert.expect(3);
 
   var component = this.subject();
-  assert.equal(component._isEditing, false);
+  assert.equal(component.isEditing, false);
 
   component.send('togglIsEditing');
-  assert.equal(component._isEditing, true);
+  assert.equal(component.isEditing, true);
 
   component.send('togglIsEditing');
-  assert.equal(component._isEditing, false);
+  assert.equal(component.isEditing, false);
 });

--- a/tests/unit/components/form-element-test.js
+++ b/tests/unit/components/form-element-test.js
@@ -24,3 +24,16 @@ test('it renders', function(assert) {
   this.render();
   assert.equal(component._state, 'inDOM');
 });
+
+test('togglIsEditing action', function(assert) {
+  assert.expect(3);
+
+  var component = this.subject();
+  assert.equal(component._isEditing, false);
+
+  component.send('togglIsEditing');
+  assert.equal(component._isEditing, true);
+
+  component.send('togglIsEditing');
+  assert.equal(component._isEditing, false);
+});

--- a/tests/unit/components/hopper-frontend-test.js
+++ b/tests/unit/components/hopper-frontend-test.js
@@ -15,10 +15,7 @@ moduleForComponent('hopper-frontend', {
   // specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar']
   needs: [
-    'adapter:application',
     'component:edit-title-input',
-    'model:form',
-    'model:formElement',
   ]
 });
 

--- a/tests/unit/components/hopper-frontend-test.js
+++ b/tests/unit/components/hopper-frontend-test.js
@@ -66,7 +66,7 @@ test('acceptTitleChange action', function(assert) {
 
 });
 
-test('addField action', function(assert) {
+test('addFormElement action', function(assert) {
   assert.expect(2);
 
   var component = this.subject();
@@ -74,7 +74,7 @@ test('addField action', function(assert) {
   this.render();
   assert.equal(component.get('form').get('formElements').length, 1);
 
-  component.send('addField', 'TestField');
+  component.send('addFormElement', 'TestField');
   assert.equal(component.get('form').get('formElements').length, 2);
 });
 

--- a/tests/unit/components/hopper-frontend-test.js
+++ b/tests/unit/components/hopper-frontend-test.js
@@ -16,6 +16,7 @@ moduleForComponent('hopper-frontend', {
   // needs: ['component:foo', 'helper:bar']
   needs: [
     'component:edit-title-input',
+    'component:element-drawer'
   ]
 });
 

--- a/tests/unit/components/hopper-frontend-test.js
+++ b/tests/unit/components/hopper-frontend-test.js
@@ -6,8 +6,17 @@ import {
 var targetObjectFake = {
   store: {
     find: function () {
-      return {};
-    }
+      return {
+        get: function() {
+          return this;
+        },
+          addObject: function() {
+            this.length = 2;
+          },
+          length: 1,
+        };
+      },
+    createRecord: function () {}
   }
 };
 
@@ -55,6 +64,18 @@ test('acceptTitleChange action', function(assert) {
   component.send('acceptTitleChange');
   assert.equal(component.isTitleBeingEdited, false);
 
+});
+
+test('addField action', function(assert) {
+  assert.expect(2);
+
+  var component = this.subject();
+  component.set('targetObject', targetObjectFake);
+  this.render();
+  assert.equal(component.get('form').get('formElements').length, 1);
+
+  component.send('addField', 'TestField');
+  assert.equal(component.get('form').get('formElements').length, 2);
 });
 
 test('css change #hopper-element-drawer after toggleIsElementDrawerOpen', function(assert) {

--- a/tests/unit/components/hopper-frontend-test.js
+++ b/tests/unit/components/hopper-frontend-test.js
@@ -3,10 +3,23 @@ import {
   test
 } from 'ember-qunit';
 
+var targetObjectFake = {
+  store: {
+    find: function () {
+      return {};
+    }
+  }
+};
+
 moduleForComponent('hopper-frontend', {
   // specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar']
-  needs: ['component:edit-title-input']
+  needs: [
+    'adapter:application',
+    'component:edit-title-input',
+    'model:form',
+    'model:formElement',
+  ]
 });
 
 test('toggleIsElementDrawerOpen action', function(assert) {
@@ -50,9 +63,10 @@ test('css change #hopper-element-drawer after toggleIsElementDrawerOpen', functi
   assert.expect(4);
 
   var component = this.subject();
+  component.set('targetObject', targetObjectFake);
 
   // append the component to the DOM
-  var $component = this.append();
+  var $component = this.render();
 
   // assert default state
   assert.ok($component.find('#hopper-element-drawer').hasClass('medium-1'));
@@ -70,9 +84,10 @@ test('css change #hopper-first-col after toggleIsElementDrawerOpen', function(as
   assert.expect(4);
 
   var component = this.subject();
+  component.set('targetObject', targetObjectFake);
 
   // append the component to the DOM
-  var $component = this.append();
+  var $component = this.render();
 
   // assert default state
   assert.ok($component.find('#hopper-first-col').hasClass('medium-15'));
@@ -90,9 +105,10 @@ test('css change #toggl-element-drawer-icon after toggleIsElementDrawerOpen', fu
   assert.expect(4);
 
   var component = this.subject();
+  component.set('targetObject', targetObjectFake);
 
   // append the component to the DOM
-  var $component = this.append();
+  var $component = this.render();
   // assert default state
   assert.ok($component.find('#toggl-element-drawer-icon').hasClass('fa-caret-left'));
   assert.ok(!$component.find('#toggl-element-drawer-icon').hasClass('fa-caret-right'));
@@ -109,9 +125,10 @@ test('css change .available-fields after toggleIsElementDrawerOpen', function(as
   assert.expect(2);
 
   var component = this.subject();
+  component.set('targetObject', targetObjectFake);
 
   // append the component to the DOM
-  var $component = this.append();
+  var $component = this.render();
 
   // assert default state
   assert.ok(!$component.find('.available-fields').hasClass('open'));
@@ -127,7 +144,9 @@ test('add and remove input', function(assert) {
   assert.expect(4);
 
   var component = this.subject();
-  var $component = this.append();
+  component.set('targetObject', targetObjectFake);
+
+  var $component = this.render();
 
   assert.ok($component.find('.form-title > h1').length);
   assert.ok(!$component.find('.form-title > input').length);
@@ -143,6 +162,8 @@ test('it renders', function(assert) {
 
   // creates the component instance
   var component = this.subject();
+  component.set('targetObject', targetObjectFake);
+
   assert.equal(component._state, 'preRender');
 
   // renders the component to the page

--- a/tests/unit/models/form-element-test.js
+++ b/tests/unit/models/form-element-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+
+moduleForModel('form-element', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  var model = this.subject();
+  // var store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/form-test.js
+++ b/tests/unit/models/form-test.js
@@ -5,7 +5,7 @@ import {
 
 moduleForModel('form', {
   // Specify the other units that are required for this test.
-  needs: []
+  needs: ['model:formElement']
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/models/form-test.js
+++ b/tests/unit/models/form-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+
+moduleForModel('form', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  var model = this.subject();
+  // var store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/routes/fields-test.js
+++ b/tests/unit/routes/fields-test.js
@@ -5,10 +5,25 @@ import {
 
 moduleFor('route:fields', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  // needs: ['model:formElement']
 });
 
 test('it exists', function(assert) {
   var route = this.subject();
   assert.ok(route);
+});
+
+test('route model', function (assert) {
+  assert.expect(2);
+  var route = this.subject();
+
+  // stubbing the store object
+  route.store = {
+    find: function(model, formId){
+      assert.equal(model, 'form');
+      return {id: formId};
+    }
+  };
+
+  assert.equal(route.model().id, 1);
 });

--- a/tests/unit/routes/form-test.js
+++ b/tests/unit/routes/form-test.js
@@ -12,3 +12,18 @@ test('it exists', function(assert) {
   var route = this.subject();
   assert.ok(route);
 });
+
+test('route model', function (assert) {
+  assert.expect(2);
+  var route = this.subject();
+
+  // stubbing the store object
+  route.store = {
+    find: function(model, formId){
+      assert.equal(model, 'form');
+      return {id: formId};
+    }
+  };
+
+  assert.equal(route.model().id, 1);
+});


### PR DESCRIPTION
This Pullrequest is the foundation for every future work. Here a summary of the changes:

**form model, formElement model and fixtures**:
I introduces two ember models which are quite small at the moment and have to be extendend from here on. I also added a `FixtureAdapter` to load and use fixtures for local testing and development.

**element-drawer component**:
It introduces the `element-drawer` component which will make it in the future easier to add new fields, because they are no longer static html but generated via a JavaScript array. It also has a `addField` action, which bubbles upwards to `hopper-frontend` component.

**form-element component**:
The `form-element component` is used to render the `formElements`. Is keeps track of the elements and can switch between an edit and presentation mode. With the help of `partials` it is possible to have different representations for the different type of fields without having multiple components.

**changes to hopper-frontend component**:
The `hopper-frontend` components now has a `addField` action, which generates a new instance of `formElement` and adds it to the current form.
